### PR TITLE
Strengthen GobLang spec with interface contract and normative conformance policy

### DIFF
--- a/README_Public_With_License.txt
+++ b/README_Public_With_License.txt
@@ -32,3 +32,24 @@ shout "Only make hoard bigger!"
 - **Host the full ecosystem on Cloudflare Pages.**
 
 Enjoy your GobLang journey! 👑🔥
+
+## 📘 Language Authority & Conformance
+- `SPEC.md` (GobLang v0.1) is the **language authority**.
+- `src/core/interpreter.js` is the current **reference implementation**.
+- Additional implementations (for example, Python) are optional **conformance implementations** and must pass conformance tests.
+
+### Reference implementation interface (required)
+- Node reference implementation must export `run(source, opts?)`.
+- Success shape: `{ stdout }` (optional `{ stderr, warnings }`).
+- Error shape: deterministic structured `{ line, col, message }` errors (thrown or returned consistently).
+
+### Conformance policy
+Conformance tests are normative and must reflect `SPEC.md`.
+If a conformance test contradicts `SPEC.md`, update the test to match `SPEC.md`.
+
+Any future implementation must pass these required commands:
+1. `npm run test:conformance` (SPEC example extraction + golden fixtures)
+2. `node tests/conformance/run.js --impl <path-to-implementation-entrypoint>` (implementation adapter matrix against the same suite)
+
+For non-Node implementations, run an implementation-specific adapter (for example):
+- `python tests/conformance/run.py --impl <path-to-python-implementation>`

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,46 @@
+# GobLang Specification (Normative) — v0.1
+
+This document is the **language authority** for GobLang.
+
+- If behavior in any implementation conflicts with this file, **this file wins**.
+- Language features, syntax, and runtime semantics are defined normatively in `SPEC.md`.
+- Breaking language changes require a version bump to this specification.
+
+## Reference implementation
+
+`src/core/interpreter.js` is the current **reference implementation**.
+
+- The reference implementation is expected to follow this specification.
+- Any mismatch should be resolved by updating implementations to match `SPEC.md`.
+
+### Reference implementation interface (required)
+
+The reference implementation must expose a stable conformance entrypoint:
+
+- Node: export `run(source, opts?)`.
+- Success shape: return `{ stdout }` and optionally `{ stderr, warnings }`.
+- Error shape: report deterministic structured errors containing `{ line, col, message }` (either by throwing structured errors or returning them consistently).
+
+## Additional implementations
+
+Alternative implementations (for example, a Python interpreter) are optional **conformance implementations**.
+
+- They are welcome, but they are not language-defining.
+- They must pass the conformance suite before being considered compliant.
+
+## Conformance policy
+
+Conformance tests are normative and must reflect `SPEC.md`.
+
+- If a conformance test contradicts `SPEC.md`, update the test to match `SPEC.md`.
+
+Required conformance commands:
+
+1. `npm run test:conformance` — runs SPEC example extraction and golden fixtures.
+2. `node tests/conformance/run.js --impl <path-to-implementation-entrypoint>` — runs the implementation adapter matrix against the same suite.
+
+For non-Node implementations, run an implementation-specific adapter, for example:
+
+- `python tests/conformance/run.py --impl <path-to-python-implementation>`
+
+An implementation is only considered conformant when all required conformance commands exit successfully.


### PR DESCRIPTION
## Summary
Addressed the review feedback by tightening enforceability in both `SPEC.md` and `README_Public_With_License.txt`.

### Changes made
- Added spec versioning at the top: `GobLang Specification (Normative) — v0.1`.
- Added explicit versioning rule: breaking language changes require a spec version bump.
- Added a required reference implementation interface contract for `src/core/interpreter.js`:
  - `run(source, opts?)`
  - Success shape `{ stdout }` with optional `{ stderr, warnings }`
  - Deterministic structured error shape `{ line, col, message }`
- Clarified conformance command intent:
  - `npm run test:conformance` covers SPEC example extraction + golden fixtures
  - `node tests/conformance/run.js --impl ...` runs adapter matrix against the same suite
- Made conformance-test authority explicit:
  - Conformance tests are normative
  - If a conformance test contradicts `SPEC.md`, tests must be updated to match `SPEC.md`

## Files changed
- `SPEC.md`
- `README_Public_With_License.txt`

## Validation
- Ran `git diff --check` (clean).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a62f46a32083308f90b251bb508c7b)